### PR TITLE
fixed the typo in the github tutorial heading

### DIFF
--- a/hw1/github.md
+++ b/hw1/github.md
@@ -1,4 +1,4 @@
-# Github Tutrial
+# Github Tutorial
 
 Oh no!
 The title of this page contains a typo.


### PR DESCRIPTION
I changed "Tutrial" to "Tutorial" within the github tutorial .md file. 