### PR TITLE
Fix grammar mistakes in the readme file

### DIFF
--- a/hw1/github.md
+++ b/hw1/github.md
@@ -1,4 +1,4 @@
-# Github Tutrial
+# Github Tutorial
 
 Oh no!
 The title of this page contains a typo.


### PR DESCRIPTION
I fixed the typo in the hw1 github.md file to read "GitHub Tutorial" as opposed to "GitHub Tutrial".