### PR TITLE
fixed append on 371

### DIFF
--- a/hw5/hw5.tex
+++ b/hw5/hw5.tex
@@ -368,7 +368,7 @@ import copy
 xs = [[1,2,3],[4,5,6]]
 ys = copy.copy(xs)
 ys.append('a')
-ys[0].append = 'b'
+ys[0].append('b')
 print('xs=',xs)
 print('ys=',ys)
 \end{python}


### PR DESCRIPTION
The append statement previously was written as: ys[0].append = 'b', which was returning an error and would not do what we want it to. I changed it to what I believe it was intended to do as: ys[0].append('b')