### PR TITLE
fix typo in git.md (NOT TUTRIAL)

### DIFF
--- a/week_00/git.md
+++ b/week_00/git.md
@@ -718,7 +718,7 @@ if __name__=='__main__':
 =======
     parser.add_argument('--message',choices=['hello','goodbye'])
     parser.add_argument('--input_name',action='store_true')
->>>>>>> master
+>>>>>>> userinput
     args = parser.parse_args()
     main(args.message,args.input_name)
 ```


### PR DESCRIPTION
I believe this is supposed to say `userinput` instead of `master` given the text that follows