### PR TITLE
fix typo

### DIFF
--- a/week_00/github.md
+++ b/week_00/github.md
@@ -1,4 +1,4 @@
-# Github Tutrial
+# Github Tutorial 
 
 Oh no!
 The title of this page contains a typo.


### PR DESCRIPTION
Fixing the typo in the github.md file.

Change `Tutrial` -> `Tutorial`