### PR TITLE
Changed i.e. to e.g. and removed an unnecessary comma.

### DIFF
--- a/topic_00_unix/README.md
+++ b/topic_00_unix/README.md
@@ -41,7 +41,7 @@ The lambda server has:
 
 **Due Date:**
 
-Labs are always due on midnight of the Sunday of the week that they are assigned (i.e. January 22 for this lab).
+Labs are always due on midnight of the Sunday of the week that they are assigned (e.g. January 22 for this lab).
 
 *For this lab only:*
 There will be no late penalty if you miss the due date,
@@ -117,6 +117,6 @@ Submit a link to your pull request in sakai.
 Homeworks will generally be posted into the `homework` [git submodule](https://www.atlassian.com/git/tutorials/git-submodule) for each week.
 Homeworks are always due on Tuesday of the week after they are assigned (i.e. Jan 24 for this homework).
 
-*For this hw only: There will be no late penalty if you miss the due date, but please be reasonable.*
+*For this hw only: There will be no late penalty if you miss the due date but please be reasonable.*
 
 


### PR DESCRIPTION
In this case, "e.g." would be more accurate than "i.e." since you are providing an example of a Sunday, not clarifying what Sunday refers to.

In addition, the comma before "please" is unnecessary since the clause beginning with "please" is dependent. (I believe this is an imperative clause if I recall correctly.)