### PR TITLE
fix typo in typespeed.md

### DIFF
--- a/caveat_tasks/typespeed.md
+++ b/caveat_tasks/typespeed.md
@@ -93,7 +93,7 @@ Therefore, this program will run with the permissions of group `games` for all u
 
 > **NOTE:**
 >
-> The effect above could also be achieved by setting the setuid bit instead of the setguid bit.
+> The effect above could also be achieved by setting the setuid bit instead of the setgid bit.
 > This would cause the program to run with `root` permissions for all users,
 > since the file is owned by `root`.
 > But this would be a VERY BAD IDEA.


### PR DESCRIPTION
Fixes typos for extra-credit in accordance with https://github.com/mikeizbicki/cmc-csci046/blob/027c57a0bbe5c68ec13ccfa5de56a4a969d78b54/extra_credit/README.md?plain=1#L5-L7