### PR TITLE
Fixed typo and inline code

### DIFF
--- a/topic_00_unix/git.md
+++ b/topic_00_unix/git.md
@@ -793,8 +793,8 @@ Programmers often talk about maintaining *clean* git histories.
 We say a repo has a clean history if it is easy to see who is working on what,
 and that there is no extra stuff in the history that we don't need.
 
-Since we're done with the `bigfix` and `userinput` branches,
-we should delete them with the `git branch -d command`.
+Since we're done with the `bugfix` and `userinput` branches,
+we should delete them with the `git branch -d` command.
 
 Run the following commands to delete these branches.
 


### PR DESCRIPTION
I fixed a typo in the unix/git tutorial. I fixed "bigfix" as I think it is meant to say "bugfix". Additionally, I corrected a potential mistake where the inline code extended out to the word "command" which seemed like a mistake.